### PR TITLE
Add missing line to the custom location manager such that new requests..

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/CustomLocationManager.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/CustomLocationManager.java
@@ -139,6 +139,7 @@ class CustomLocationManager implements LocationEngine {
     @Override
     public void requestLocationUpdates(LocationEngineRequest request, LocationEngineCallback<LocationEngineResult> callback, Looper looper){
         this.callbacks.add(callback);
+        this.requests.add(request);
         if (this.customLocation == null){
             // If the fallbackLocationEngine is used forward the request to it.
             this.fallbackLocationEngine.requestLocationUpdates(request, callback, looper);


### PR DESCRIPTION
get added to the requests list. The missing line caused apps to crash when disposing the map (tried to remove requests from the requests list that were not there).